### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/Controllers/PaymentsController.cs
+++ b/Controllers/PaymentsController.cs
@@ -51,7 +51,8 @@ public class PaymentsController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing payment for order {OrderId}", request.OrderId);
+            var safeOrderId = request.OrderId?.ToString().Replace("\r", "").Replace("\n", "");
+            _logger.LogError(ex, "Error processing payment for order {OrderId}", safeOrderId);
             return StatusCode(500, new PaymentResultDto 
             { 
                 IsSuccess = false, 


### PR DESCRIPTION
Potential fix for [https://github.com/aioutlet/payment-service/security/code-scanning/1](https://github.com/aioutlet/payment-service/security/code-scanning/1)

To fix this issue, we must sanitize the user-supplied `OrderId` before logging. The recommended fix is to strip line breaks and other control characters from `OrderId`, ensuring it cannot be used for log forging. This can be done using `string.Replace` or a regular expression to eliminate problematic characters. The safest approach is to apply `.Replace("\r", "").Replace("\n", "")` or use a regex to remove all control characters. Edits should be made directly in the line where logging occurs—in this case, line 54 in Controllers/PaymentsController.cs.

If `OrderId` is not a string (e.g., int), then logging it directly is not problematic. But since nothing in the code shows its type and we want to future-proof against type changes, it's safest to handle it as a string defensively.

No new imports are needed for basic string replacement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
